### PR TITLE
MultiDict initialization bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ if not hasattr(sys.modules[__name__], '__file__'):
     __file__ = inspect.getfile(inspect.currentframe())
 ```
 
+added workaround to [cython bug #600](http://trac.cython.org/ticket/600) at MultiDict initialization
+
+from (around line 1817):
+```python
+    def __init__(self, *a, **k):
+        self.dict = dict((k, [v]) for (k, v) in dict(*a, **k).items())
+```
+
+to:
+```python
+    def __init__(self, *a, **k):
+        items = dict(*a, **k).items()
+        self.dict = dict((k, [v]) for (k, v) in items)
+```
+
 ----------
 ### version 0.10.9 (stable) ###
 added initialization of `__file__` from around line 69

--- a/bottle.py
+++ b/bottle.py
@@ -1814,7 +1814,8 @@ class MultiDict(DictMixin):
     """
 
     def __init__(self, *a, **k):
-        self.dict = dict((k, [v]) for (k, v) in dict(*a, **k).items())
+        items = dict(*a, **k).items()
+        self.dict = dict((k, [v]) for (k, v) in items)
 
     def __len__(self): return len(self.dict)
     def __iter__(self): return iter(self.dict)


### PR DESCRIPTION
Fixes this error:

```
>>> from bottle import MultiDict
>>> x = MultiDict()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "bottle.pyx", line 1817, in bottle.MultiDict.__init__ (/Users/leandro/.pyxbld/temp.macosx-10.6-intel-3.4/pyrex/bottle.c:47866)
    self.dict = dict((k, [v]) for (k, v) in dict(*a, **k).items())
  File "bottle.pyx", line 1817, in genexpr (/Users/leandro/.pyxbld/temp.macosx-10.6-intel-3.4/pyrex/bottle.c:47768)
    self.dict = dict((k, [v]) for (k, v) in dict(*a, **k).items())
UnboundLocalError: local variable 'k' referenced before assignment
>>> 
```
